### PR TITLE
fix(x86_64): explicitly decrease alignment of i128 to 8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermit-entry"
-version = "0.9.9"
+version = "0.9.10"
 authors = ["Martin Kröning <mkroening@posteo.net>"]
 edition = "2021"
 description = "Hermit's loading and entry API."

--- a/src/boot_info/kernel.rs
+++ b/src/boot_info/kernel.rs
@@ -66,7 +66,10 @@ impl From<RawPlatformInfo> for PlatformInfo {
                 has_pci,
                 num_cpus,
                 cpu_freq,
-                boot_time: OffsetDateTime::from_unix_timestamp_nanos(boot_time).unwrap(),
+                boot_time: OffsetDateTime::from_unix_timestamp_nanos(i128::from_ne_bytes(
+                    boot_time.0,
+                ))
+                .unwrap(),
             },
             RawPlatformInfo::LinuxBootParams {
                 command_line_data,

--- a/src/boot_info/loader.rs
+++ b/src/boot_info/loader.rs
@@ -54,7 +54,7 @@ impl From<PlatformInfo> for RawPlatformInfo {
                 has_pci,
                 num_cpus,
                 cpu_freq,
-                boot_time: boot_time.unix_timestamp_nanos(),
+                boot_time: boot_time.unix_timestamp_nanos().to_ne_bytes().into(),
             },
             PlatformInfo::LinuxBootParams {
                 command_line,

--- a/src/boot_info/mod.rs
+++ b/src/boot_info/mod.rs
@@ -158,6 +158,17 @@ struct RawLoadInfo {
     tls_info: TlsInfo,
 }
 
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(target_arch = "x86_64", repr(C, align(8)))]
+#[cfg_attr(not(target_arch = "x86_64"), repr(transparent))]
+struct Align8<T>(pub T);
+
+impl<T> From<T> for Align8<T> {
+    fn from(value: T) -> Self {
+        Self(value)
+    }
+}
+
 #[cfg_attr(not(all(feature = "loader", feature = "kernel")), allow(dead_code))]
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
@@ -174,7 +185,7 @@ enum RawPlatformInfo {
         has_pci: bool,
         num_cpus: NonZeroU64,
         cpu_freq: Option<NonZeroU32>,
-        boot_time: i128,
+        boot_time: Align8<[u8; 16]>,
     },
     LinuxBootParams {
         command_line_data: *const u8,


### PR DESCRIPTION
This fixes https://github.com/hermit-os/kernel/pull/1071#issuecomment-1961598278.