### PR TITLE
feat(v4/0.10.0): add `PlatformInfo::Fdt` for transitioning to FDTs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermit-entry"
-version = "0.9.10"
+version = "0.10.0"
 authors = ["Martin Kröning <mkroening@posteo.net>"]
 edition = "2021"
 description = "Hermit's loading and entry API."

--- a/src/boot_info/kernel.rs
+++ b/src/boot_info/kernel.rs
@@ -89,6 +89,7 @@ impl From<RawPlatformInfo> for PlatformInfo {
                     boot_params_addr,
                 }
             }
+            RawPlatformInfo::Fdt => Self::Fdt,
         }
     }
 }

--- a/src/boot_info/loader.rs
+++ b/src/boot_info/loader.rs
@@ -66,6 +66,7 @@ impl From<PlatformInfo> for RawPlatformInfo {
                 command_line_len: command_line.map(|s| s.len() as u64).unwrap_or(0),
                 boot_params_addr,
             },
+            PlatformInfo::Fdt => Self::Fdt,
         }
     }
 }

--- a/src/boot_info/mod.rs
+++ b/src/boot_info/mod.rs
@@ -109,6 +109,11 @@ pub enum PlatformInfo {
         /// Address to Linux boot parameters.
         boot_params_addr: core::num::NonZeroU64,
     },
+    /// FDT.
+    ///
+    /// This is a transitional platform for migrating to FDTs.
+    /// The real platform information is stored in [`HardwareInfo::device_tree`].
+    Fdt,
 }
 
 /// Thread local storage (TLS) image information.
@@ -192,4 +197,5 @@ enum RawPlatformInfo {
         command_line_len: u64,
         boot_params_addr: core::num::NonZeroU64,
     },
+    Fdt,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ const NT_HERMIT_ENTRY_VERSION: u32 = 0x5a00;
 
 /// The current hermit entry version.
 #[cfg_attr(not(all(feature = "loader", feature = "kernel")), allow(dead_code))]
-const HERMIT_ENTRY_VERSION: u8 = 3;
+const HERMIT_ENTRY_VERSION: u8 = 4;
 
 /// Offsets and values used to interpret the boot params ("zeropage") setup by firecracker
 /// For the full list of values see


### PR DESCRIPTION
This adds a new `PlatformInfo::Fdt` for transitioning to FDTs. The real platform information is stored in `HardwareInfo::device_tree`.

Closes https://github.com/hermit-os/hermit-entry/pull/29.

CC: @sarahspberrypi, @jounathaen 