### PR TITLE
feat(loader): add support for `R_ABS64` and `R_GLOB_DAT` relocation types

### DIFF
--- a/src/elf.rs
+++ b/src/elf.rs
@@ -159,8 +159,8 @@ impl<'a> KernelObject<'a> {
             .find(|program_header| program_header.p_type == program_header::PT_DYNAMIC)
             .map(|ph| {
                 let start = ph.p_offset as usize;
-                let len = (ph.p_filesz as usize) / dynamic::SIZEOF_DYN;
-                Dyn::slice_from_bytes_len(&elf[start..], len).unwrap()
+                let len = ph.p_filesz as usize;
+                Dyn::slice_from_bytes(&elf[start..][..len]).unwrap()
             })
             .unwrap_or_default();
 
@@ -175,8 +175,8 @@ impl<'a> KernelObject<'a> {
 
         let relas = {
             let start = dynamic_info.rela;
-            let len = dynamic_info.relacount;
-            Rela::slice_from_bytes_len(&elf[start..], len).unwrap()
+            let len = dynamic_info.relasz;
+            Rela::slice_from_bytes(&elf[start..][..len]).unwrap()
         };
 
         assert!(relas

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -292,7 +292,7 @@ impl<'a> KernelObject<'a> {
                 let file_len = ph.p_filesz as usize;
                 let ph_file = &self.elf[ph.p_offset as usize..][..file_len];
                 // FIXME: Replace with `maybe_uninit_write_slice` once stable
-                let ph_file = unsafe { mem::transmute(ph_file) };
+                let ph_file = unsafe { mem::transmute::<&[u8], &[MaybeUninit<u8>]>(ph_file) };
                 ph_memory[..file_len].copy_from_slice(ph_file);
                 for byte in &mut ph_memory[file_len..] {
                     byte.write(0);
@@ -306,7 +306,7 @@ impl<'a> KernelObject<'a> {
                 let relocated = (start_addr as i64 + rela.r_addend).to_ne_bytes();
                 let buf = &relocated[..];
                 // FIXME: Replace with `maybe_uninit_write_slice` once stable
-                let buf = unsafe { mem::transmute(buf) };
+                let buf = unsafe { mem::transmute::<&[u8], &[MaybeUninit<u8>]>(buf) };
                 memory[rela.r_offset as usize..][..mem::size_of_val(&relocated)]
                     .copy_from_slice(buf);
             });


### PR DESCRIPTION
This makes sure that we don't only look at relative relocations. Then, this implements support for `R_ABS64` and `R_GLOB_DATA` and prints helpful errors on unknown relocation types.

This makes PIEs possible with gcc.