### PR TITLE
Added command line and environment to the hermit entry parameters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hermit-entry"
-version = "0.10.1"
-authors = ["Martin Kröning <mkroening@posteo.net>"]
+version = "0.11.0"
+authors = ["Martin Kröning <mkroening@posteo.net>", "Jonathan Klimt <jonathan.klimt@rwth-aachen.de>"]
 edition = "2021"
 description = "Hermit's loading and entry API."
 repository = "https://github.com/hermitcore/hermit-entry"

--- a/src/boot_info/kernel.rs
+++ b/src/boot_info/kernel.rs
@@ -62,15 +62,29 @@ impl From<RawPlatformInfo> for PlatformInfo {
                 num_cpus,
                 cpu_freq,
                 boot_time,
-            } => Self::Uhyve {
-                has_pci,
-                num_cpus,
-                cpu_freq,
-                boot_time: OffsetDateTime::from_unix_timestamp_nanos(i128::from_ne_bytes(
-                    boot_time.0,
-                ))
-                .unwrap(),
-            },
+                command_line_data,
+                command_line_len,
+                env,
+            } => {
+                let command_line = (!command_line_data.is_null()).then(|| {
+                    // SAFETY: cmdline and cmdsize are valid forever.
+                    let slice = unsafe {
+                        core::slice::from_raw_parts(command_line_data, command_line_len as usize)
+                    };
+                    core::str::from_utf8(slice).unwrap()
+                });
+                Self::Uhyve {
+                    has_pci,
+                    num_cpus,
+                    cpu_freq,
+                    boot_time: OffsetDateTime::from_unix_timestamp_nanos(i128::from_ne_bytes(
+                        boot_time.0,
+                    ))
+                    .unwrap(),
+                    command_line,
+                    env,
+                }
+            }
             RawPlatformInfo::LinuxBootParams {
                 command_line_data,
                 command_line_len,

--- a/src/boot_info/loader.rs
+++ b/src/boot_info/loader.rs
@@ -50,11 +50,18 @@ impl From<PlatformInfo> for RawPlatformInfo {
                 num_cpus,
                 cpu_freq,
                 boot_time,
+                command_line,
+                env,
             } => Self::Uhyve {
                 has_pci,
                 num_cpus,
                 cpu_freq,
                 boot_time: boot_time.unix_timestamp_nanos().to_ne_bytes().into(),
+                env,
+                command_line_data: command_line
+                    .map(|s| s.as_ptr())
+                    .unwrap_or(core::ptr::null()),
+                command_line_len: command_line.map(|s| s.len() as u64).unwrap_or(0),
             },
             PlatformInfo::LinuxBootParams {
                 command_line,

--- a/src/boot_info/mod.rs
+++ b/src/boot_info/mod.rs
@@ -100,6 +100,18 @@ pub enum PlatformInfo {
 
         /// Boot time.
         boot_time: OffsetDateTime,
+
+        /// Command line (program name and command line arguments) passed to
+        /// the kernel.
+        command_line: Option<&'static str>,
+
+        /// Environment variables: First element is a pointer to the beginning
+        /// of the envp, second element is a pointer to the beginning of the
+        /// raw env data. The length of the envp is
+        /// `(env.0 - env.1) / size_of::<u64>()`.
+        /// The last pointer in envp points to the end of the environemen data,
+        /// and not to a valid environment variable!
+        env: Option<(NonZeroU64, NonZeroU64)>,
     },
     /// Linux Boot Parameters.
     LinuxBootParams {
@@ -191,6 +203,9 @@ enum RawPlatformInfo {
         num_cpus: NonZeroU64,
         cpu_freq: Option<NonZeroU32>,
         boot_time: Align8<[u8; 16]>,
+        env: Option<(NonZeroU64, NonZeroU64)>,
+        command_line_data: *const u8,
+        command_line_len: u64,
     },
     LinuxBootParams {
         command_line_data: *const u8,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ const NT_HERMIT_ENTRY_VERSION: u32 = 0x5a00;
 
 /// The current hermit entry version.
 #[cfg_attr(not(all(feature = "loader", feature = "kernel")), allow(dead_code))]
-const HERMIT_ENTRY_VERSION: u8 = 4;
+const HERMIT_ENTRY_VERSION: u8 = 5;
 
 /// Offsets and values used to interpret the boot params ("zeropage") setup by firecracker
 /// For the full list of values see


### PR DESCRIPTION
I'd like to get rid of the hypercalls in uhyve just to retrieve the env and argv. I think it makes sense to add them to the boot information, as they are available at boot time anyway.

(Once implemented in uhyve and hermit, this would solve https://github.com/hermit-os/uhyve/issues/35)